### PR TITLE
Deadline related fixes

### DIFF
--- a/src/ctx.erl
+++ b/src/ctx.erl
@@ -3,6 +3,7 @@
 -export([set/3,
          get/2,
          get/3,
+         values/1,
          new/0,
          background/0,
          deadline/1,
@@ -12,6 +13,7 @@
          with_value/3,
          with_values/1,
          with_deadline/1,
+         with_deadline/2,
          with_deadline_after/2,
          with_deadline_after/3,
          time_to_deadline/1,
@@ -43,6 +45,10 @@ get(#ctx{values=Values}, Key) ->
 get(#ctx{values=Values}, Key, Default) ->
     maps:get(Key, Values, Default).
 
+-spec values(t()) -> map().
+values(#ctx{values=Values}) ->
+    Values.
+
 -spec with_value(t(), term(), term()) -> t().
 with_value(Ctx=#ctx{values=Values}, Key, Value) ->
     Ctx#ctx{values=maps:put(Key, Value, Values)}.
@@ -60,6 +66,10 @@ with_deadline(Deadline) ->
     #ctx{values=#{},
          deadline=Deadline}.
 
+-spec with_deadline(t(), {integer(), integer()} | undefined | infinity) -> t().
+with_deadline(Ctx, Deadline) ->
+    Ctx#ctx{deadline=Deadline}.
+
 -spec with_deadline_after(integer(), erlang:time_unit()) -> t().
 with_deadline_after(After, Unit) ->
     with_deadline_after(#ctx{values=#{}}, After, Unit).
@@ -70,9 +80,7 @@ with_deadline_after(Ctx, After, Unit) ->
 
 -spec deadline(t()) -> {integer(), integer()} | undefined | infinity.
 deadline(#ctx{deadline=Deadline}) ->
-    Deadline;
-deadline(_) ->
-    undefined.
+    Deadline.
 
 -spec time_to_deadline(t()) -> integer() | undefined | infinity.
 time_to_deadline(Ctx) ->

--- a/src/ctx.erl
+++ b/src/ctx.erl
@@ -13,7 +13,9 @@
          with_values/1,
          with_deadline/1,
          with_deadline_after/2,
-         with_deadline_after/3]).
+         with_deadline_after/3,
+         time_to_deadline/1,
+         time_to_deadline/2]).
 
 -export_type([t/0]).
 
@@ -68,7 +70,32 @@ with_deadline_after(Ctx, After, Unit) ->
 
 -spec deadline(t()) -> {integer(), integer()} | undefined | infinity.
 deadline(#ctx{deadline=Deadline}) ->
-    Deadline.
+    Deadline;
+deadline(_) ->
+    undefined.
+
+-spec time_to_deadline(t()) -> integer() | undefined | infinity.
+time_to_deadline(Ctx) ->
+    case deadline(Ctx) of
+        undefined ->
+            undefined;
+        infinity ->
+            infinity;
+        {Deadline, _} ->
+            Deadline - erlang:monotonic_time()
+    end.
+
+-spec time_to_deadline(t(), erlang:time_unit()) -> integer() | undefined | infinity.
+time_to_deadline(Ctx, Unit) ->
+    case deadline(Ctx) of
+        undefined ->
+            undefined;
+        infinity ->
+            infinity;
+        {Deadline, _} ->
+            TTD = Deadline - erlang:monotonic_time(),
+            erlang:convert_time_unit(TTD, native, Unit)
+    end.
 
 -spec done(t()) -> boolean().
 done(#ctx{deadline={Deadline, _}}) ->

--- a/src/ctx.erl
+++ b/src/ctx.erl
@@ -72,7 +72,7 @@ deadline(#ctx{deadline=Deadline}) ->
 
 -spec done(t()) -> boolean().
 done(#ctx{deadline={Deadline, _}}) ->
-    erlang:monotonic_time() =< Deadline;
+    erlang:monotonic_time() >= Deadline;
 done(_) ->
     false.
 


### PR DESCRIPTION
preparation for a PR I would like to do to grpcbox to support deadlines longer then 5s

* fix `done` compare
* `time_to_deadline` to be able to know how long to recv in grpcbox
* more access functions